### PR TITLE
Update Scala to avoid a compiler bug and add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+CS4200: Compiler Construction Project Template
+======
+
+This repository contains a template which allows students to implement
+labs for the CS4200 using a text editor or IDE of their own choice. Be
+aware that this template is provided by the course staff on a best
+effort basis and that no official support will be given. It is
+therefore recommended that assignments are done on Brightspace
+instead.
+
+> **Warning**
+>  Please do not forget to hand-in **all** assignments using
+> Brightspace, otherwise they *cannot* and *will not* be graded.
+
+Dependencies
+------
+- [SBT](https://www.scala-sbt.org/)
+
+Usage
+------
+- `sbt compile`: Separately compile the program.
+- `sbt run`: runs the main class of the program.
+- `sbt test`: execute all the tests of the program.
+- `sbt testQuick`: only execute the tests that failed or did not run
+  before.
+- `sbt tasks`: an overview of the tasks that can be run.
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
-ThisBuild / scalaVersion := "2.12.2"
+ThisBuild / scalaVersion := "2.12.16"
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
There is a [compiler](https://github.com/sbt/sbt/issues/5093) bug in the older Scala version which causes SBT to crash if the SDK is newer than 12. By updating it to the latest maintenance  release of the `2.12.x` branch. It also adds a rather small README with some basic information about dependencies and what commands you can run. 